### PR TITLE
Add professional Vite login page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Shipping Logistics Login</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "logistics-login",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "element-plus": "^2.8.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^5.0.0"
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="login-page">
+    <el-row justify="center" align="middle" class="login-row">
+      <el-col :span="8">
+        <el-card class="box-card">
+          <div class="logo">Shipping Logistics</div>
+          <el-form :model="form" @submit.prevent="onSubmit" label-position="top">
+            <el-form-item label="Email">
+              <el-input v-model="form.email" type="email" placeholder="Email" autocomplete="email" />
+            </el-form-item>
+            <el-form-item label="Password">
+              <el-input v-model="form.password" type="password" placeholder="Password" autocomplete="current-password" />
+            </el-form-item>
+            <el-form-item>
+              <el-button type="primary" style="width: 100%" @click="onSubmit">Login</el-button>
+            </el-form-item>
+          </el-form>
+        </el-card>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue';
+import { ElMessage } from 'element-plus';
+
+const form = reactive({
+  email: '',
+  password: ''
+});
+
+function onSubmit() {
+  console.log('Login with:', form);
+  // TODO: Replace with real authentication logic
+  ElMessage.success('Login attempt');
+}
+</script>
+
+<style>
+.login-page {
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(to right, #66a6ff, #89f7fe);
+}
+.logo {
+  text-align: center;
+  font-size: 24px;
+  color: #409EFF;
+  margin-bottom: 20px;
+  font-weight: bold;
+}
+.box-card {
+  padding: 20px;
+}
+.login-row {
+  width: 100%;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,6 @@
+import { createApp } from 'vue';
+import ElementPlus from 'element-plus';
+import 'element-plus/dist/index.css';
+import App from './App.vue';
+
+createApp(App).use(ElementPlus).mount('#app');

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()]
+});


### PR DESCRIPTION
## Summary
- migrate to a simple Vite project
- create App.vue login page using Element Plus
- configure main.js and Vite

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683be07e04ec832d9039b3618acdf629